### PR TITLE
Change regex to accept pandoc 2.0

### DIFF
--- a/pandocxnos/core.py
+++ b/pandocxnos/core.py
@@ -150,7 +150,7 @@ def init(pandocversion=None, doc=None):
 
     global _PANDOCVERSION  # pylint: disable=global-statement
 
-    pattern = re.compile(r'^1\.[0-9]+(?:\.[0-9]+)?(?:\.[0-9]+)?$')
+    pattern = re.compile(r'(^1\.[0-9]+(?:\.[0-9]+)?(?:\.[0-9]+)?$)|(^2.0)')
 
     if 'PANDOC_VERSION' in os.environ:  # Available for pandoc >= 1.19.1
         pandocversion = str(os.environ['PANDOC_VERSION'])


### PR DESCRIPTION
With `pandoc` 2.0 compiled locally all of the `xnos` repos throw ```RuntimeError: Cannot understand pandocversion=2.0```; because version `2.0` is not supported in the _current_ or _nextrelease_ branches.

This PR adds changes the regex that does the version matching to support 2.0.

---

I have not done extensive testing on 2.0, but it parses my Markdown without any errors and functionality still works. I could not find any tests, but if you point me to the right place I'll be more than happy to fix anything that is broken.