### PR TITLE
Fixed bug https://github.com/tomduck/pandoc-eqnos/issues/30

### DIFF
--- a/pandocxnos/core.py
+++ b/pandocxnos/core.py
@@ -890,6 +890,8 @@ def insert_secnos_factory(f):
                 sec = sec[:MAXLEVEL]
             if key == name:
                 s = '.'.join([str(n) for n in sec])
+                if 2 not in value[0]:
+                    value[0][2] = []
                 value[0][2].insert(0, ['secno', s])
 
     return insert_secnos


### PR DESCRIPTION
This commit fixes bug that appears in another repository: https://github.com/tomduck/pandoc-eqnos/issues/30

When using `xnos-number-sections: On`, it seems like all equations need an identifier `{#eq:}`. If not, an error is thrown. When NOT using this option, equation is not numbered and that is fine. We would expect the same behaviour with this option

Below is minimal markdown file that reproduce the error:

I use the latest versions of pandoc-eqnos with command

    pip install -U pandoc-eqnos


File `bug.md`

    ---
    xnos-number-sections: On
    ...

    # Title 1

    $$ x $$ {#eq:}

    Symbol $x$ has no reference

Pandoc command:

    pandoc --mathml --filter pandoc-eqnos -o bug.html bug.md


Error message:

    Traceback (most recent call last):
      File "c:\program files\python36\lib\runpy.py", line 193, in _run_module_as_main
        "__main__", mod_spec)
      File "c:\program files\python36\lib\runpy.py", line 85, in _run_code
        exec(code, run_globals)
      File "C:\Program Files\Python36\Scripts\pandoc-eqnos.exe\__main__.py", line 9, in <module>
      File "c:\program files\python36\lib\site-packages\pandoc_eqnos.py", line 301, in main
        detach_attrs_math], blocks)
      File "c:\program files\python36\lib\site-packages\pandoc_eqnos.py", line 298, in <lambda>
        altered = functools.reduce(lambda x, action: walk(x, action, fmt, meta),
      File "c:\program files\python36\lib\site-packages\pandocfilters.py", line 113, in walk
        array.append(walk(item, action, format, meta))
      File "c:\program files\python36\lib\site-packages\pandocfilters.py", line 124, in walk
        x[k] = walk(x[k], action, format, meta)
      File "c:\program files\python36\lib\site-packages\pandocfilters.py", line 111, in walk
        item['c'] if 'c' in item else None, format, meta)
      File "c:\program files\python36\lib\site-packages\pandocxnos\core.py", line 893, in insert_secnos
        value[0][2].insert(0, ['secno', s])
    KeyError: 2
    Error running filter pandoc-eqnos:
    Filter returned error status 1