### PR TITLE
Update core.py

### DIFF
--- a/pandocxnos/core.py
+++ b/pandocxnos/core.py
@@ -633,6 +633,8 @@ def process_refs_factory(labels):
             _process_refs(value[-2], labels)
         elif key == 'Table':
             _process_refs(value[-5], labels)
+        elif key == 'Span':
+            _process_refs(value[-1], labels)
         elif key == 'Emph':
             _process_refs(value, labels)
         elif key == 'Strong':


### PR DESCRIPTION
I noticed that pandoc-fignos references didn't work when they are inside spans.  This corrects the problem.  So this works now:

  <span>{*@fig:foo}</span>

However, a span defined like this still does not work, I believe pandoc sees this as a citation and not a span:

  [{*@fig:foo}]

I am using this to apply a custom character style for docx output, like this:

  <span custom-style="mystyle">{*@fig:foo}</span>

I had some spots in a document that I didn't want to pickup the default blue underline hyperlink formatting for the exhibit number.  An alternative would be to add a reference syntax that inserts the exhibit number as text, not a link, in the output.  I.e., define a new prefix like {^@fig::foo}.