### PR TITLE
Try fixing a bug that sometimes "cleveref_fakery" was inserted into wrong position

### DIFF
--- a/pandocxnos/core.py
+++ b/pandocxnos/core.py
@@ -716,7 +716,7 @@ def replace_refs_factory(references, use_cleveref_default, use_eqref,
                 value[1] = value[1] + '\n' + '\n'.join(tex1[1:])
                 _cleveref_tex_flag = False  # Cleveref fakery already installed
 
-        elif key != 'RawBlock':  # Write the cleveref TeX
+        if _cleveref_tex_flag:  # Write the cleveref TeX
             _cleveref_tex_flag = False  # Cancels further attempts
             ret = []
 


### PR DESCRIPTION
When working with another filter [pandoc-latex-admonition](https://github.com/chdemko/pandoc-latex-admonition), if filter `pandoc-fignos` is applied after `pandoc-latex-admonition`, the "cleveref_fakery" raw tex is inserted into a wrong position.

See an example:

````markdown
---
pandoc-latex-admonition:
    - color: dodgerblue
      classes: [con]
      linewidth: 3
      margin: 12
      innermargin: 24
fignos-cleveref: True
---

```con
python
```
````

Run `pandoc -o test.tex --filter=pandoc-latex-admonition --filter=pandoc-fignos file.md'. Get a wrong result, which cann't be converted to pdf:

**The wrong tex**:
```tex
\begin{env-1b47dc9f-88e2-4639-809e-2e9091ef6b4a}

% pandoc-xnos: cleveref fakery
\newcommand{\plusnamesingular}{}
\newcommand{\starnamesingular}{}
\newcommand{\xrefname}[1]{\protect\renewcommand{\plusnamesingular}{#1}}
\newcommand{\Xrefname}[1]{\protect\renewcommand{\starnamesingular}{#1}}
\providecommand{\cref}{\plusnamesingular~\ref}
\providecommand{\Cref}{\starnamesingular~\ref}
\providecommand{\crefformat}[2]{}
\providecommand{\Crefformat}[2]{}

% pandoc-xnos: cleveref formatting
\crefformat{figure}{fig.~#2#1#3}
\Crefformat{figure}{Figure~#2#1#3}

\begin{verbatim}
python
\end{verbatim}

\end{env-1b47dc9f-88e2-4639-809e-2e9091ef6b4a}
```

Which `\begin{env-*************}` should be right before `\begin{verbatim}`.

After some testing, this commit fixed this specific issue. But I'm not sure I understand the philosophy of this filter, so tell me what to do if I'm wrong.