### PR TITLE
Add non-breaking space for non-TeX cleverefs

### DIFF
--- a/pandocxnos/core.py
+++ b/pandocxnos/core.py
@@ -41,6 +41,7 @@ from .pandocattributes import PandocAttributes
 
 # pylint: disable=too-many-lines
 
+NON_BREAKING_SPACE = " "
 
 #=============================================================================
 # Globals
@@ -966,7 +967,7 @@ def replace_refs_factory(references, use_cleveref_default, use_eqref,
                   if _PANDOCVERSION < '1.16' else \
                   Link(['', [], []], [elem], ['%s#%s' % (prefix, label), ''])
 
-            ret = ([Str(refname), Space()] if use_cleveref else []) + [elem]
+            ret = ([Str(refname + NON_BREAKING_SPACE)] if use_cleveref else []) + [elem]
 
         # If the Cite was square-bracketed then wrap everything in a span
         s = stringify(value[-1])


### PR DESCRIPTION
This solves https://github.com/tomduck/pandoc-fignos/issues/78 by mandatorily adding a non-breaking space between the reference name and its number.