### PR TITLE
Enable using Pandoc 3.x and higher

### DIFF
--- a/pandocxnos/core.py
+++ b/pandocxnos/core.py
@@ -171,7 +171,7 @@ def _get_pandoc_version(pandocversion, doc):
             pass
 
     # Test `pandocversion` and if it is OK then return it
-    pattern = re.compile(r'^[1-2]\.[0-9]+(?:\.[0-9]+)?(?:\.[0-9]+)?$')
+    pattern = re.compile(r'^[1-9]\.[0-9]+(?:\.[0-9]+)?(?:\.[0-9]+)?$')
     if pandocversion is not None:
         if pattern.match(pandocversion):
             return pandocversion


### PR DESCRIPTION
The current version does not work with Pandoc 3.x because of a too restrictive regular expression used for checking Pandoc version. Could you, please, make a new release so that the filters can be used with Pandoc 3.x and higher? Thank you! 